### PR TITLE
Specify bridged tokens

### DIFF
--- a/docs/wxm-token.md
+++ b/docs/wxm-token.md
@@ -41,9 +41,9 @@ The Token Launch Day is the day that the station owners will start receiving $WX
 
 ### Arbitrum
 
-- Token: [0xB6093B61544572Ab42A0E43AF08aBaFD41bf25A6](https://arbiscan.io/address/0xB6093B61544572Ab42A0E43AF08aBaFD41bf25A6)
+- Token (*Bridged from Ethereum*): [0xB6093B61544572Ab42A0E43AF08aBaFD41bf25A6](https://arbiscan.io/address/0xB6093B61544572Ab42A0E43AF08aBaFD41bf25A6)
 - Rewards Vault: [0x93F1A412050BaB0C317844361E4cC801ED5aca72](https://arbiscan.io/address/0x93F1A412050BaB0C317844361E4cC801ED5aca72)
 - Rewards Pool: [0x2CDBa04dcFD3999ef3FDa00121b23c693AF4041b](https://arbiscan.io/address/0x2CDBa04dcFD3999ef3FDa00121b23c693AF4041b)
 
 ### Solana
-- Token: [wxmJYe17a2oGJZJ1wDe6ZyRKUKmrLj2pJsavEdTVhPP](https://solscan.io/token/wxmJYe17a2oGJZJ1wDe6ZyRKUKmrLj2pJsavEdTVhPP)
+- Token (*Bridged from Ethereum*): [wxmJYe17a2oGJZJ1wDe6ZyRKUKmrLj2pJsavEdTVhPP](https://solscan.io/token/wxmJYe17a2oGJZJ1wDe6ZyRKUKmrLj2pJsavEdTVhPP)


### PR DESCRIPTION
According to @vrypan [comment](https://github.com/weatherxm-network/weatherxm-network.github.io/pull/20#issuecomment-2162780534). Specify that the Arbitrum and Solana tokens are bridged.